### PR TITLE
Revert "use the private drm lib name"

### DIFF
--- a/va/Android.mk
+++ b/va/Android.mk
@@ -92,7 +92,7 @@ LOCAL_MODULE := libva
 LOCAL_MODULE_CLASS := SHARED_LIBRARIES
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_CFLAGS += -Wno-error
-LOCAL_SHARED_LIBRARIES := libdl libdrm_pri libcutils liblog
+LOCAL_SHARED_LIBRARIES := libdl libdrm libcutils liblog
 ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
 LOCAL_HEADER_LIBRARIES += libutils_headers
 endif
@@ -136,7 +136,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libva-android
 LOCAL_PROPRIETARY_MODULE := true
 
-LOCAL_SHARED_LIBRARIES := libva libdrm_pri libnativewindow liblog
+LOCAL_SHARED_LIBRARIES := libva libdrm libnativewindow liblog
 
 ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
 LOCAL_STATIC_LIBRARIES += libarect


### PR DESCRIPTION
Remove the corresponding patch from aosp_diff,
modification is moved here.

Tracked-On: OAM-88717
Signed-off-by: yifang ma <yifangx.ma@intel.com>