### PR TITLE
Upgrade libva to 2.7.1 upstream for 2020 Q1 rebase

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
-libva NEWS -- summary of user visible changes.  2020-03-26
+libva NEWS -- summary of user visible changes.  2020-04-18
 Copyright (C) 2009-2020 Intel Corporation
+
+version 2.7.1 - 18.Apr.2020
+* VA/X11: enable driver candidate selection for DRI2
+* VA/X11: VAAPI driver mapping for iris DRI driver 
 
 version 2.7.0 - 26.Mar.2020
 * trace: av1 decode buffers trace

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ m4_define([va_api_version],
 m4_define([libva_major_version], [m4_eval(va_api_major_version + 1)])
 m4_define([libva_minor_version], [m4_eval(va_api_minor_version)])
 m4_define([libva_micro_version], [0])
-m4_define([libva_pre_version],   [1])
+m4_define([libva_pre_version],   [0])
 
 m4_define([libva_version],
           [libva_major_version.libva_minor_version.libva_micro_version])

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ m4_define([va_api_version],
 # - reset micro version to zero when VA-API major or minor version is changed
 m4_define([libva_major_version], [m4_eval(va_api_major_version + 1)])
 m4_define([libva_minor_version], [m4_eval(va_api_minor_version)])
-m4_define([libva_micro_version], [0])
+m4_define([libva_micro_version], [1])
 m4_define([libva_pre_version],   [0])
 
 m4_define([libva_version],

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # - reset micro version to zero when VA-API major or minor version is changed
 project(
   'libva', 'c',
-  version : '2.7.0.1',
+  version : '2.7.0',
   meson_version : '>= 0.37.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # - reset micro version to zero when VA-API major or minor version is changed
 project(
   'libva', 'c',
-  version : '2.7.0',
+  version : '2.7.1',
   meson_version : '>= 0.37.0',
   default_options : [ 'warning_level=1',
                       'buildtype=debugoptimized' ])

--- a/va/Android.mk
+++ b/va/Android.mk
@@ -25,8 +25,8 @@
 
 LOCAL_PATH:= $(call my-dir)
 
-LIBVA_DRIVERS_PATH_32 := /vendor/lib/dri
-LIBVA_DRIVERS_PATH_64 := /vendor/lib64/dri
+LIBVA_DRIVERS_PATH_32 := /vendor/lib/:/system/lib
+LIBVA_DRIVERS_PATH_64 := /vendor/lib64/:/system/lib64
 
 include $(CLEAR_VARS)
 
@@ -56,13 +56,47 @@ LOCAL_CFLAGS := \
 	-DLOG_TAG=\"libva\"
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
+LOCAL_COPY_HEADERS := \
+     va.h \
+     va_version.h \
+     va_dec_hevc.h \
+     va_dec_jpeg.h \
+     va_dec_vp8.h \
+     va_dec_vp9.h \
+     va_enc_hevc.h \
+     va_enc_h264.h \
+     va_enc_jpeg.h \
+     va_enc_vp8.h \
+     va_backend.h \
+     va_drmcommon.h \
+     va_vpp.h \
+     va_backend_vpp.h \
+     va_enc_mpeg2.h \
+     sysdeps.h \
+     va_compat.h \
+     va_egl.h \
+     va_enc_vp9.h \
+     va_fei.h \
+     va_fei_h264.h \
+     va_fei_hevc.h \
+     va_fool.h \
+     va_internal.h \
+     va_str.h \
+     va_tpi.h \
+     va_trace.h \
+     va_dec_av1.h \
+
+LOCAL_COPY_HEADERS_TO := libva/va
 
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libva
 LOCAL_MODULE_CLASS := SHARED_LIBRARIES
 LOCAL_PROPRIETARY_MODULE := true
-
+LOCAL_CFLAGS += -Wno-error
 LOCAL_SHARED_LIBRARIES := libdl libdrm libcutils liblog
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
+LOCAL_HEADER_LIBRARIES += libutils_headers
+endif
 
 intermediates := $(call local-generated-sources-dir)
 
@@ -95,10 +129,20 @@ LOCAL_CFLAGS += \
 LOCAL_C_INCLUDES += \
 	$(LOCAL_PATH)/drm
 
+LOCAL_COPY_HEADERS_TO := libva/va
+
+LOCAL_COPY_HEADERS := va_android.h		
+
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libva-android
 LOCAL_PROPRIETARY_MODULE := true
 
-LOCAL_SHARED_LIBRARIES := libva libdrm liblog
+LOCAL_SHARED_LIBRARIES := libva libdrm libnativewindow liblog
+
+ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
+LOCAL_STATIC_LIBRARIES += libarect
+LOCAL_HEADER_LIBRARIES += libnativebase_headers libutils_headers
+endif
+
 
 include $(BUILD_SHARED_LIBRARY)

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -53,6 +53,8 @@ struct driver_name_map {
 static const struct driver_name_map g_dri2_driver_name_map[] = {
     { "i965",       4, "iHD"    }, // Intel iHD  VAAPI driver with i965 DRI driver
     { "i965",       4, "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
+    { "iris",       4, "iHD"    }, // Intel iHD  VAAPI driver with iris DRI driver
+    { "iris",       4, "i965"   }, // Intel i965 VAAPI driver with iris DRI driver
     { NULL,         0, NULL }
 };
 

--- a/va/x11/va_x11.c
+++ b/va/x11/va_x11.c
@@ -44,6 +44,18 @@
 #include <fcntl.h>
 #include <errno.h>
 
+struct driver_name_map {
+    const char *key;
+    int         key_len;
+    const char *name;
+};
+
+static const struct driver_name_map g_dri2_driver_name_map[] = {
+    { "i965",       4, "iHD"    }, // Intel iHD  VAAPI driver with i965 DRI driver
+    { "i965",       4, "i965"   }, // Intel i965 VAAPI driver with i965 DRI driver
+    { NULL,         0, NULL }
+};
+
 static int va_DisplayContextIsValid (
     VADisplayContextP pDisplayContext
 )
@@ -73,28 +85,92 @@ static void va_DisplayContextDestroy (
     free(pDisplayContext);
 }
 
-
-static VAStatus va_DRI2GetDriverName (
+static VAStatus va_DRI2_GetNumCandidates (
     VADisplayContextP pDisplayContext,
-    char **driver_name
+    int *num_candidates
 )
 {
+    char *driver_name = NULL;
+    const struct driver_name_map *m = NULL;
     VADriverContextP ctx = pDisplayContext->pDriverContext;
 
-    if (!va_isDRI2Connected(ctx, driver_name))
+    *num_candidates = 0;
+
+    if (!(va_isDRI2Connected(ctx, &driver_name) && driver_name))
         return VA_STATUS_ERROR_UNKNOWN;
+
+    for (m = g_dri2_driver_name_map; m->key != NULL; m++) {
+        if (strlen(driver_name) >= m->key_len &&
+            strncmp(driver_name, m->key, m->key_len) == 0) {
+            (*num_candidates)++;
+        }
+    }
+
+    free(driver_name);
+
+    /*
+     * If the dri2 driver name does not have a mapped vaapi driver name, then
+     * assume they have the same name.
+     */
+    if (*num_candidates == 0)
+        *num_candidates = 1;
+
+    return VA_STATUS_SUCCESS;
+}
+
+static VAStatus va_DRI2_GetDriverName (
+    VADisplayContextP pDisplayContext,
+    char **driver_name_ptr,
+    int candidate_index
+)
+{
+    const struct driver_name_map *m = NULL;
+    int current_index = 0;
+    VADriverContextP ctx = pDisplayContext->pDriverContext;
+
+    *driver_name_ptr = NULL;
+
+    if (!(va_isDRI2Connected(ctx, driver_name_ptr) && *driver_name_ptr))
+        return VA_STATUS_ERROR_UNKNOWN;
+
+    for (m = g_dri2_driver_name_map; m->key != NULL; m++) {
+        if (strlen(*driver_name_ptr) >= m->key_len &&
+            strncmp(*driver_name_ptr, m->key, m->key_len) == 0) {
+            if (current_index == candidate_index) {
+                break;
+            }
+            current_index++;
+        }
+    }
+
+    /*
+     * If the dri2 driver name does not have a mapped vaapi driver name, then
+     * assume they have the same name.
+     */
+    if (!m->name)
+        return VA_STATUS_SUCCESS;
+
+    /* Use the mapped vaapi driver name */
+    free(*driver_name_ptr);
+    *driver_name_ptr = strdup(m->name);
+    if (!*driver_name_ptr)
+        return VA_STATUS_ERROR_ALLOCATION_FAILED;
 
     return VA_STATUS_SUCCESS;
 }
 
 static VAStatus va_NVCTRL_GetDriverName (
     VADisplayContextP pDisplayContext,
-    char **driver_name
+    char **driver_name,
+    int candidate_index
 )
 {
     VADriverContextP ctx = pDisplayContext->pDriverContext;
     int direct_capable, driver_major, driver_minor, driver_patch;
     Bool result;
+
+    if (candidate_index != 0)
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
 
     result = VA_NVCTRLQueryDirectRenderingCapable(ctx->native_dpy, ctx->x11_screen,
                                                   &direct_capable);
@@ -112,12 +188,16 @@ static VAStatus va_NVCTRL_GetDriverName (
 
 static VAStatus va_FGLRX_GetDriverName (
     VADisplayContextP pDisplayContext,
-    char **driver_name
+    char **driver_name,
+    int candidate_index
 )
 {
     VADriverContextP ctx = pDisplayContext->pDriverContext;
     int driver_major, driver_minor, driver_patch;
     Bool result;
+
+    if (candidate_index != 0)
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
 
     result = VA_FGLRXGetClientDriverName(ctx->native_dpy, ctx->x11_screen,
                                          &driver_major, &driver_minor,
@@ -130,24 +210,43 @@ static VAStatus va_FGLRX_GetDriverName (
 
 static VAStatus va_DisplayContextGetDriverName (
     VADisplayContextP pDisplayContext,
-    char **driver_name
+    char **driver_name, int candidate_index
 )
 {
     VAStatus vaStatus;
 
     if (driver_name)
-	*driver_name = NULL;
+        *driver_name = NULL;
     else
         return VA_STATUS_ERROR_UNKNOWN;
-    
-    vaStatus = va_DRI2GetDriverName(pDisplayContext, driver_name);
+
+    vaStatus = va_DRI2_GetDriverName(pDisplayContext, driver_name, candidate_index);
     if (vaStatus != VA_STATUS_SUCCESS)
-        vaStatus = va_NVCTRL_GetDriverName(pDisplayContext, driver_name);
+        vaStatus = va_NVCTRL_GetDriverName(pDisplayContext, driver_name, candidate_index);
     if (vaStatus != VA_STATUS_SUCCESS)
-        vaStatus = va_FGLRX_GetDriverName(pDisplayContext, driver_name);
+        vaStatus = va_FGLRX_GetDriverName(pDisplayContext, driver_name, candidate_index);
+
     return vaStatus;
 }
 
+static VAStatus va_DisplayContextGetNumCandidates (
+    VADisplayContextP pDisplayContext,
+    int *num_candidates
+)
+{
+    VAStatus vaStatus;
+
+    vaStatus = va_DRI2_GetNumCandidates(pDisplayContext, num_candidates);
+
+    /* A call to va_DisplayContextGetDriverName will fallback to other
+     * methods (i.e. NVCTRL, FGLRX) when DRI2 is unsuccessful.  All of those
+     * fallbacks only have 1 candidate driver.
+     */
+    if (vaStatus != VA_STATUS_SUCCESS)
+      *num_candidates = 1;
+
+    return VA_STATUS_SUCCESS;
+}
 
 VADisplay vaGetDisplay (
     Display *native_dpy /* implementation specific */
@@ -166,7 +265,8 @@ VADisplay vaGetDisplay (
 
     pDisplayContext->vaIsValid       = va_DisplayContextIsValid;
     pDisplayContext->vaDestroy       = va_DisplayContextDestroy;
-    pDisplayContext->vaGetDriverName = va_DisplayContextGetDriverName;
+    pDisplayContext->vaGetNumCandidates = va_DisplayContextGetNumCandidates;
+    pDisplayContext->vaGetDriverNameByIndex = va_DisplayContextGetDriverName;
 
     pDriverContext = va_newDriverContext(pDisplayContext);
     if (!pDriverContext) {
@@ -190,7 +290,6 @@ VADisplay vaGetDisplay (
     return (VADisplay)pDisplayContext;
 }
 
-
 void va_TracePutSurface (
     VADisplay dpy,
     VASurfaceID surface,
@@ -207,7 +306,6 @@ void va_TracePutSurface (
     unsigned int number_cliprects, /* number of clip rects in the clip list */
     unsigned int flags /* de-interlacing flags */
 );
-
 
 VAStatus vaPutSurface (
     VADisplay dpy,


### PR DESCRIPTION
Upgrade libva to 2.7.1 upstream for supporting media-driver 2020 Q1 rebase